### PR TITLE
Remove display: block on label spans

### DIFF
--- a/scss/base/forms.scss
+++ b/scss/base/forms.scss
@@ -397,7 +397,6 @@ input.checkbox {
 
   + label span {
     color: $gray-base-30;
-    display: block;
     margin-bottom: $baseline-grid * 2;
     margin-left: 6px;
   }


### PR DESCRIPTION
I guess we probably don't want to do `display: block` generally for all spans inside labels... It's causing this for a new radio button:

![bildschirmfoto 2016-09-24 um 19 15 34](https://cloud.githubusercontent.com/assets/1935696/18809994/5ed2cfae-828b-11e6-9797-cfbb98903fa4.png)

**Code**

``` html
<div class="radio">
  <input id="type_employer" value="employer" type="radio">

  <label for="type_employer">
    Mitarbeitern

    <span class="text-sm text-muted">
      (38)
    </span>
  </label>
</div>
```

@kaytcat what do you think? Can we remove this safely?
