### PR TITLE
Fix headings weight in kununu-theme

### DIFF
--- a/packages/kununu-theme/package.json
+++ b/packages/kununu-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kununu-theme",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Base scss styles for kununu",
   "scripts": {
     "test": "echo \"No test specified\""

--- a/packages/kununu-theme/scss/base/forms.scss
+++ b/packages/kununu-theme/scss/base/forms.scss
@@ -218,7 +218,6 @@ label.block.optional {
   color: $gray-base-30;
   float: right;
   font-family: $font-family-sans-serif;
-  font-weight: 400;
   font-size: $font-size-xs;
   font-style: italic;
   padding-top: $baseline-grid;
@@ -372,9 +371,8 @@ input.checkbox {
   + label {
     color: $gray-base-80;
     cursor: pointer;
-    font-weight: $font-weight-semibold;
+    font-weight: normal;
     padding-left: 30px;
-    letter-spacing: -.01em;
 
     &:before {
       border-radius: 50%;

--- a/packages/kununu-theme/scss/base/type.scss
+++ b/packages/kununu-theme/scss/base/type.scss
@@ -113,24 +113,19 @@ h1, .h1 {
   @media (max-width: $screen-md-max) {
     font-size: 18px;
   }
-  font-weight: 200;
-  letter-spacing: .03em;
+  font-weight: bold;
   line-height: $line-height-h1;
   margin-bottom: $baseline-grid * 4;
   margin-top: $baseline-grid * 4;
 }
 
 h2, .h2 {
-  font-weight: 200;
-  letter-spacing: .03em;
   line-height: $line-height-h2;
   margin-bottom: $baseline-grid * 3;
   margin-top: $baseline-grid * 4;
 }
 
 h3, .h3 {
-  font-weight: 200;
-  letter-spacing: .03em;
   line-height: $line-height-h3;
   margin-bottom: $baseline-grid * 3;
   margin-top: $baseline-grid * 4;


### PR DESCRIPTION
- Heading weights were changed accidentally when the v2 theme was updated. I've reset them back to the way they were before and removed any letter-spacing in preparation for system-fonts in monolith. 