### PR TITLE
Use less bootstrap deps

### DIFF
--- a/packages/kununu-theme-v2/package.json
+++ b/packages/kununu-theme-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/kununu-theme-v2",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Base scss styles for kununu applications",
   "scripts": {
     "test": "echo \"No test specified\""

--- a/packages/kununu-theme-v2/scss/base/core.scss
+++ b/packages/kununu-theme-v2/scss/base/core.scss
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 // Sticky footer
 // -------------
 
@@ -15,6 +19,11 @@ body {
   -webkit-font-smoothing: subpixel-antialiased;
   font-smoothing: auto;
   font-weight: 400;
+  font-family: $font-family-base;
+  font-size: $font-size-base;
+  line-height: $line-height-base;
+  color: $text-color;
+  background-color: $body-bg;
   padding-top: $navbar-height;
 
   > header.navbar {
@@ -37,6 +46,25 @@ body {
 
 a {
   @include transition(.25s color);
+  color: $link-color;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    color: $link-hover-color;
+    text-decoration: $link-hover-decoration;
+  }
+}
+
+ul,
+ol {
+  margin-top: 0;
+  margin-bottom: ($line-height-computed / 2);
+
+  ul,
+  ol {
+    margin-bottom: 0;
+  }
 }
 
 iframe {

--- a/packages/kununu-theme-v2/scss/base/mixins.scss
+++ b/packages/kununu-theme-v2/scss/base/mixins.scss
@@ -14,6 +14,29 @@
   text-shadow: 0 1px 1px rgba(0, 0, 0, .15);
 }
 
+@mixin transition($transition...) {
+  -webkit-transition: $transition;
+  -o-transition: $transition;
+  transition: $transition;
+}
+
+@mixin clearfix() {
+  &:before,
+  &:after {
+    content: ' ';
+    display: table;
+  }
+
+  &:after {
+    clear: both;
+  }
+}
+
+@mixin box-shadow($shadow...) {
+  -webkit-box-shadow: $shadow;
+  box-shadow: $shadow;
+}
+
 @mixin button-variant(
   $color,
   $background,


### PR DESCRIPTION
In order to allow our projects to move away from bootstrap I've started moving a few crucial mixins and core styles into the theme. These changes allow us to run the header/footer completely without bootstrap with this pr: https://github.com/kununu/client-gear/pull/54

*The only thing is that your project must include some sort of normalizer.